### PR TITLE
ajout endpoint DELETE api/handleImages

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,6 +2,7 @@ const express = require("express");
 const path = require("path");
 // route export module
 const formatRoutes = require("./routes/format");
+const handleImagesRoutes = require("./routes/handleImages");
 
 const ENV = process.env;
 
@@ -16,12 +17,21 @@ app.use((req, res, next) => {
 
 app.use(express.json());
 
-//route API
-app.use("/api/onepic", formatRoutes);
+//*** START ROUTE API
 
-//static serve
+//format
+app.use("/api/onepic", formatRoutes);
+//handleImages
+app.use("/api/handleImages", handleImagesRoutes);
+
+//ROUTE API FINISH***
+
+
+// *** START STATIC SERVE
+
 //picture compress
-// eslint-disable-next-line no-undef
 app.use("/assets", express.static(path.join(__dirname, ENV.FOLDER_PIC_COMPRESS)));
+
+// STATIC SERVE FINISH ***
 
 module.exports = app;

--- a/controllers/format.js
+++ b/controllers/format.js
@@ -73,7 +73,7 @@ const compressPicture = (req, res, tcomp) => {
             if (ENV.MODE === "development") {
                 console.log("picktureLink : ", pinctureLink);
             }
-            res.status(200).json({pictureLink: pinctureLink});
+            res.status(200).json({pictureLink: pinctureLink, filename : req.file.filename});
         });
 };
 

--- a/controllers/handleImages.js
+++ b/controllers/handleImages.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+
+exports.deletePicture = (req, res) => {
+    const filename = req.params.filename;
+    // suppression de l'image compressé
+    fs.unlink(`${process.env.FOLDER_PIC_COMPRESS}/${process.env.PICTURE_PREFIX + filename}`, (error) => {
+        if (!error) {
+            // puis suppression de l'image d'origine
+            fs.unlink(`temp/${filename}`, () => {
+                if (!error) {
+                    res.status(200).json({ message : "image supprimé avec succès !"});
+                }else {
+                    res.status(400).json({ error });
+                }
+            });
+        }else {
+            res.status(400).json({ error });
+        }
+    });
+};

--- a/routes/handleImages.js
+++ b/routes/handleImages.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const handleImagesCtrl = require("../controllers/handleImages");
+
+router.delete("/:filename", handleImagesCtrl.deletePicture);
+
+module.exports = router;


### PR DESCRIPTION
suppression de l'image temporaire et compressé dans l'api une fois que le client à fait un choix: soit il sauvegarde l'image compressé sur son périphérique , soit il annule.